### PR TITLE
Fixes some deprecation-cop warnings

### DIFF
--- a/typescript-atomizer-plugin/lib/TypeScriptWorkspace.ts
+++ b/typescript-atomizer-plugin/lib/TypeScriptWorkspace.ts
@@ -36,7 +36,6 @@ class TypeScriptWorkspace implements Disposable
         this._atom = atom;
         this._textEditorStates = { };
         this._workspace = atom.workspace;
-        this._workspaceView = atom.workspaceView;
         this._viewRegistry = atom.views;
         this._statusBar = null;
 
@@ -212,11 +211,15 @@ class TypeScriptWorkspace implements Disposable
 
             statusBarView.setModel(this._statusBar);
 
-            if (this._workspaceView.statusBar)
+            var globalStatusBarView: StatusBar = <any> document.querySelector("status-bar")
+            if (globalStatusBarView)
             {
                 statusBarView.classList.add("inline-block");
 
-                this._workspaceView.statusBar.prependLeft(statusBarView);
+                globalStatusBarView.addLeftTile({
+                    item: statusBarView,
+                    priority: -1
+                });
             }
         }
 

--- a/typings/atom.d.ts
+++ b/typings/atom.d.ts
@@ -267,7 +267,7 @@ interface TextEditor
      * @returns {Disposable} A disposable on which 'dispose' can be called to unsubscribe.
      */
     onDidStopChanging(callback: () => void): Disposable;
-    
+
     /**
      * Invoke the given callback when the underlying buffer's path changes.
      *
@@ -316,8 +316,8 @@ interface Disposable
 
 interface StatusBar
 {
-    prependLeft(view: HTMLElement);
-    appendLeft(view: HTMLElement);
+    addLeftTile(options: { item: any; priority: number; });
+    addRightTile(options: { item: any; priority: number; });
 }
 
 /**


### PR DESCRIPTION
Hey Tim!

Remember me?
I'm not stalking you, honest :)
I was just in the market for a new typescript-aware editor when I stumbled onto this plugin written by no other than my genius former colleague!

This pull request fixes the atom (approx version 0.174.0) deprecation-cop warnings regarding the status bar and workspace view. I'm not so sure about the -1 for the priority... but it seems to work. The docs here https://atom.io/packages/status-bar don't mention valid ranges so I figure anything goes.
